### PR TITLE
Adds support for non-embed YouTube URLs by converting them to embed format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,36 +3,37 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
-## [Unreleased]
 
-## [2.5.0] - 2024-10-01
+## 2.6.0 - 2025-05-07
+### Added
+- Rewrite of YouTube video URLs into standardized embed URLs
+
+## 2.5.0 - 2024-10-01
 ### Added
 - Option to prevent pop-ups caused by the clickable YouTube logo
 
-## [2.4.0] - 2024-08-28
+## 2.4.0 - 2024-08-28
 ### Added
 - Support for cookie consent that was released with PWA 6.23.0 (backwards compatible)
 
-## [2.3.1] - 2022-12-08
+## 2.3.1 - 2022-12-08
 ### Changed
 - small css improvements
 
-## [2.3.0] - 2022-09-15
+## 2.3.0 - 2022-09-15
 ### Changed
 - Option to add a headline to the YouTube container
 - Configuration to add a spacing on both sides
 
-## [2.2.0] - 2022-09-15
+## 2.2.0 - 2022-09-15
 ### Changed
 - Video property value does not need to be a complete Youtube URL anymore, but just the ID
 
-## [2.1.0] - 2021-05-03
+## 2.1.0 - 2021-05-03
 ### Added
 - configuration for additional portal positions
 
-## [1.0.0] - 2018-06-21
+## 1.0.0 - 2018-06-21
 ### Added
 - first implementation
 
-[Unreleased]: https://github.com/shopgate/ext-youtube-pdp/compare/v1.0.0...HEAD
-[0.1.0]: https://github.com/shopgate/ext-youtube-pdp/tree/v1.0.0

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.0",
+  "version": "2.5.0",
   "id": "@shopgate/youtube-pdp",
   "components": [
     {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "id": "@shopgate/youtube-pdp",
   "components": [
     {

--- a/frontend/YouTubeVideo/selectors.js
+++ b/frontend/YouTubeVideo/selectors.js
@@ -3,7 +3,115 @@ import { getCurrentProductId, getProductPropertiesState } from '@shopgate/engage
 import { videoProperty } from '../config';
 
 /**
- * Selects the youtube url from the current product.
+ * Generates a YouTube embed URL from either a full YouTube URL or a raw video ID.
+ *
+ * Supported input formats:
+ * - Raw video ID: "zSEmjzsDpLA"
+ * - Raw video ID with query: "zSEmjzsDpLA?autoplay=1"
+ * - https://www.youtube.com/watch?v=VIDEO_ID
+ * - https://youtu.be/VIDEO_ID
+ * - https://m.youtube.com/watch?v=VIDEO_ID
+ * - https://www.youtube.com/shorts/VIDEO_ID
+ * - https://www.youtube.com/embed/VIDEO_ID (returns as-is with param merge)
+ *
+ * If optional parameters are provided, they will override any query parameters
+ * already present in the input.
+ *
+ * @param {string} input - A YouTube video ID or a full YouTube URL.
+ * @param {Object} [params={}] - Optional query parameters to include or override.
+ * @returns {string|null} - A properly formatted YouTube embed URL, or null if input is invalid.
+ */
+function getYouTubeEmbedUrl(input, params = {}) {
+  if (!input) return null;
+
+  let videoId = null;
+  let existingParams = {};
+
+  try {
+    // Try to parse the input as a URL
+    const parsed = new URL(input);
+
+    // CASE 1: Input is already an embed URL
+    if (
+      parsed.hostname.includes('youtube.com') &&
+      parsed.pathname.startsWith('/embed/')
+    ) {
+      const embedUrl = new URL(input);
+
+      // Merge new params into the existing query string, overriding duplicates
+      // eslint-disable-next-line no-restricted-syntax
+      for (const [key, value] of Object.entries(params)) {
+        embedUrl.searchParams.set(key, value);
+      }
+
+      return embedUrl.toString();
+    }
+
+    if (parsed.hostname === 'youtu.be') {
+      // CASE 2: Short URL format (e.g. https://youtu.be/VIDEO_ID)
+      videoId = parsed.pathname.slice(1); // remove leading slash
+      existingParams = Object.fromEntries(parsed.searchParams.entries());
+    } else if (
+      // CASE 3: Standard YouTube watch page (e.g. https://www.youtube.com/watch?v=VIDEO_ID)
+      parsed.hostname.includes('youtube.com') &&
+      parsed.pathname === '/watch'
+    ) {
+      videoId = parsed.searchParams.get('v');
+      existingParams = Object.fromEntries(parsed.searchParams.entries());
+    } else if (
+      // CASE 4: Shorts format (e.g. https://www.youtube.com/shorts/VIDEO_ID)
+      parsed.hostname.includes('youtube.com') &&
+      parsed.pathname.startsWith('/shorts/')
+    ) {
+      const [, shortId] = parsed.pathname.split('/shorts/');
+      videoId = shortId;
+      existingParams = Object.fromEntries(parsed.searchParams.entries());
+    }
+
+    // Other formats like playlists or channels are ignored
+  } catch {
+    // CASE 5: Input is not a valid URL — maybe it's a raw video ID with optional query string
+
+    // Try to split on "?" to separate ID from query parameters
+    const [rawId, queryString] = input.split('?');
+
+    // Validate that the ID matches the YouTube video ID format
+    if (/^[\w-]{11}$/.test(rawId)) {
+      videoId = rawId;
+
+      // Parse additional query string parameters if provided
+      if (queryString) {
+        const queryParams = new URLSearchParams(queryString);
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [key, value] of queryParams.entries()) {
+          existingParams[key] = value;
+        }
+      }
+    } else {
+      // Not a valid ID or URL
+      return null;
+    }
+  }
+
+  // If we couldn't determine a video ID, return null
+  if (!videoId) return null;
+
+  // Construct the base embed URL
+  const embedUrl = new URL(`https://www.youtube.com/embed/${videoId}`);
+
+  // Merge existing parameters and override with explicit ones from `params`
+  const finalParams = { ...existingParams, ...params };
+
+  // Apply all final query parameters to the embed URL
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [key, value] of Object.entries(finalParams)) {
+    embedUrl.searchParams.set(key, value);
+  }
+
+  return embedUrl.toString();
+}
+/**
+ * Selects the YouTube url from the current product.
  * @param {Object} state The current application state.
  * @return {string|null}
  */
@@ -18,12 +126,11 @@ export const getCurrentYoutubeUrl = createSelector(
 
     const videoProp = entry.properties.find(prop => prop.label === videoProperty) || {};
 
-    // If we just receive a youtube videos's ID we have to append the embed
-    // youtube url before it so that it can be played in the iframe
-    if (videoProp.value && !videoProp.value.includes('https://www.youtube.com')) {
-      return `https://www.youtube.com/embed/${videoProp.value}`;
-    }
-
-    return (videoProp.value || null);
+    return getYouTubeEmbedUrl(videoProp.value, {
+      // Enable the js api to allow sending events to the iframe.
+      enablejsapi: 1,
+      // Enable controls to avoid the iframe not being resumable because of controls=0 param on ios.
+      controls: 1,
+    });
   }
 );

--- a/frontend/YouTubeVideo/selectors.js
+++ b/frontend/YouTubeVideo/selectors.js
@@ -39,10 +39,9 @@ function getYouTubeEmbedUrl(input, params = {}) {
       const embedUrl = new URL(input);
 
       // Merge new params into the existing query string, overriding duplicates
-      // eslint-disable-next-line no-restricted-syntax
-      for (const [key, value] of Object.entries(params)) {
+      Object.entries(params).forEach(([key, value]) => {
         embedUrl.searchParams.set(key, value);
-      }
+      });
 
       return embedUrl.toString();
     }
@@ -103,10 +102,9 @@ function getYouTubeEmbedUrl(input, params = {}) {
   const finalParams = { ...existingParams, ...params };
 
   // Apply all final query parameters to the embed URL
-  // eslint-disable-next-line no-restricted-syntax
-  for (const [key, value] of Object.entries(finalParams)) {
+  Object.entries(finalParams).forEach(([key, value]) => {
     embedUrl.searchParams.set(key, value);
-  }
+  });
 
   return embedUrl.toString();
 }


### PR DESCRIPTION
## Description

This pull request introduces compatibility with standard and short-form YouTube URLs (e.g. watch?v=..., youtu.be/..., shorts/...). These are now automatically converted into the proper embed format internally, allowing them to be used reliably in <iframe> elements.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## How to test
The most simple way to test the fix is the manipulate [this selector](https://github.com/shopgate/ext-youtube-pdp/blob/fbb6f3af033a8b9c2ba33973d12cbaaa5a6eba62/frontend/YouTubeVideo/selectors.js#L127)

Just replace this line with (url from the YouTube website)

```js
const videoProp = {
  value: 'https://www.youtube.com/watch?v=WrBw9zO4z58',
};
```

or (pure YouTube video id)
```js
const videoProp = {
  value: 'WrBw9zO4z58',
};
```
